### PR TITLE
Test recipe files contain command and expected res

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,15 @@ Define the first target of your `Makefile` (or if it is not the first target, se
 `.DEFAULT_GOAL := help`) as:
 
 ``` make
+help: DIR := $(HOME)/.local/share/makefile-doc
+help: URL := github.com/drdv/makefile-doc/releases/latest/download/makefile-doc.awk
 help: ## show this help
-	@test -f .external/makefile-doc.awk || \
-	wget --quiet -P .external github.com/drdv/makefile-doc/releases/latest/download/makefile-doc.awk
-	@awk -f .external/makefile-doc.awk $(MAKEFILE_LIST)
+	@test -f $(DIR)/makefile-doc.awk || wget --quiet -P $(DIR) $(URL)
+	@awk -f $(DIR)/makefile-doc.awk $(MAKEFILE_LIST)
 ```
 
-This will download the awk script on the fly (if it doesn't exist in `.external`). As an
-alternative of `wget` you could use `curl`:
+This will download the awk script on the fly (if it doesn't exist in
+`~/.local/share/makefile-doc`). As an alternative of `wget` you could use `curl`:
 
 ```
 curl -sLO --create-dirs --output-dir .external github.com/drdv/makefile-doc/releases/latest/download/makefile-doc.awk
@@ -122,11 +123,11 @@ Cloning this repository (at tag `v0.1`) and running `make` outputs:
 ## Running the tests
 
 Execute `make test` (this uses the system's default `awk`). To test with a custom
-`awk`, use:
+`awk`, use (you need a standard build environment):
 
 + `make test AWK=mawk`
 + `make test AWK=nawk`
-+ `make test AWK=bawk` (not available for macos)
++ `make test AWK=bawk` (binaries not available for macos)
 + `make test AWK=wak`
 
 Note that the makefiles in `./test` are not meant to be used manually, they are part of

--- a/test/expected_output/test-backticks
+++ b/test/expected_output/test-backticks
@@ -1,4 +1,4 @@
-# awk -v COLOR_BACKTICKS=1 -f makefile-doc.awk Makefile.inc
+> -v COLOR_BACKTICKS=1 test/Makefile.inc
 -----------------------
 Available targets:
 -----------------------

--- a/test/expected_output/test-connected
+++ b/test/expected_output/test-connected
@@ -1,4 +1,4 @@
-# awk -v CONNECTED=0 -f makefile-doc.awk Makefile.inc
+> -v CONNECTED=0 test/Makefile.inc
 -----------------------
 Available targets:
 -----------------------

--- a/test/expected_output/test-default
+++ b/test/expected_output/test-default
@@ -1,4 +1,4 @@
-# awk -f makefile-doc.awk Makefile Makefile.inc
+> test/Makefile test/Makefile.inc
 [35mRedefined docs of target: test-3[0m
 [35mRedefined docs of target: test-10[0m
 -----------------------

--- a/test/expected_output/test-deprecated
+++ b/test/expected_output/test-deprecated
@@ -1,4 +1,4 @@
-# awk -v DEPRECATED=0 -f makefile-doc.awk Makefile.inc
+> -v DEPRECATED=0 test/Makefile.inc
 -----------------------
 Available targets:
 -----------------------

--- a/test/expected_output/test-no-anchors
+++ b/test/expected_output/test-no-anchors
@@ -1,2 +1,2 @@
-# awk -v VARS=0 -f makefile-doc.awk Makefile.vars-2
+> -v VARS=0 test/Makefile.vars-2
 There are no documented targets/variables.

--- a/test/expected_output/test-no-vars
+++ b/test/expected_output/test-no-vars
@@ -1,4 +1,4 @@
-# awk -v VARS=0 -f makefile-doc.awk Makefile.vars-1
+> -v VARS=0 test/Makefile.vars-1
 -----------------------
 Available targets:
 -----------------------

--- a/test/expected_output/test-padding
+++ b/test/expected_output/test-padding
@@ -1,4 +1,4 @@
-# awk -v PADDING=. -f makefile-doc.awk Makefile.inc
+> -v PADDING=. test/Makefile.inc
 -----------------------
 Available targets:
 -----------------------

--- a/test/expected_output/test-vars
+++ b/test/expected_output/test-vars
@@ -1,4 +1,4 @@
-# awk -f makefile-doc.awk Makefile.vars-1
+> test/Makefile.vars-1
 [35mRedefined docs of variable: VAR6[0m
 -----------------------
 Available targets:

--- a/test/expected_output/test-vars-assignment
+++ b/test/expected_output/test-vars-assignment
@@ -1,4 +1,4 @@
-# awk -f makefile-doc.awk Makefile.vars-2
+> test/Makefile.vars-2
 [35mRedefined docs of variable: a4[0m
 [35mRedefined docs of variable: b4[0m
 [35mRedefined docs of variable: c4[0m


### PR DESCRIPTION
Each test is defined in a file whose first line is the command to execute (or rather a part of it) and below it are the results. It is a simplified version of [cram](https://bitheap.org/cram).