### PR TITLE
Bugfix: don't allow docs overriding in WIP targets

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -105,3 +105,16 @@ test-11: ## The top empty description shadows this
    ## --
 ##
 test-12:
+
+## Top description to remain
+test-13: ## This shouldn't affect the description
+test-13: ## Neither should this
+test-13: ## Nor this
+test-13: ##
+test-13: ## etc.
+
+## But this top description will be overriden by the following target
+test-14:
+
+test-14:
+test-14: ## An empty line marks the start of a new target

--- a/test/recipes/test-default
+++ b/test/recipes/test-default
@@ -1,5 +1,6 @@
 > test/Makefile test/Makefile.inc
 [35m[test/Makefile] redefined docs of target: test-3[0m
+[35m[test/Makefile] redefined docs of target: test-14[0m
 [35m[test/Makefile.inc] redefined docs of target: test-10[0m
 -----------------------
 Available targets:
@@ -48,6 +49,8 @@ Available targets:
 [34mtest-12            [0m
                       --
 
+[34mtest-13            [0m   Top description to remain
+[34mtest-14            [0m   An empty line marks the start of a new target
 [34mhelp               [0m   associate this with the help target (and not `.PHONY`)
                       second line in the description of the target help
 -----------------------


### PR DESCRIPTION
Closes #20.

The strategy is to keep a target as WIP until there is an empty line.