### PR TITLE
Add option to output debug info in org-mode format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ AWK := awk
 AWK_FLAGS :=
 AWK_BIN := $(TEST_DIR)/bin
 
+## Debug info is generated if set
+DEBUG :=
+
 # using $1 instead of $(AWK) is necessary for a target like
 # deps: $(AWK_BIN)/mawk $(AWK_BIN)/nawk $(AWK_BIN)/bawk $(AWK_BIN)/wak
 define verify-download
@@ -25,7 +28,8 @@ endef
 
 .PHONY: help
 ## show this help
-help: VFLAG := -v EXPANDED_TARGETS='$$(TESTS):test-:$(subst test-,,$(TESTS))'
+help: VFLAG := -v EXPANDED_TARGETS='$$(TESTS):test-:$(subst test-,,$(TESTS))' \
+	-v DEBUG=$(DEBUG)
 help: $(AWK_BIN)/$(AWK)
 	@$< $(VFLAG) $(AWK_FLAGS) -f ./makefile-doc.awk $(MAKEFILE_LIST)
 

--- a/README.md
+++ b/README.md
@@ -95,13 +95,16 @@ value"](https://www.gnu.org/software/make/manual/html_node/Simple-Assignment.htm
 The following options can be passed to `awk` using `-v option=value` (possible values
 are given in `{...}`, `(.)` shows the default)
 
++ `DEBUG`: {(0), 1} output debug info (in an org-mode format)
++ `DEBUG_FILE`: debug info file
 + `EXPANDED_TARGETS`: see [Expanded targets](#expanded-targets)
-+ `TARGET_REGEX`: regex to use for target matching
-* `VARS`: `{0, (1)}` 1 show documented variables; 0 don't show
++ `TARGETS_REGEX`: regex to use for matching targets
++ `VARIABLES_REGEX`: regex to use for matching variables
+* `VARS`: `{0, (1)}` show documented variables
 * `PADDING`: `{(" "), ".", ...}` a single padding character between anchors and docs
-* `DEPRECATED`: `{0, (1)}` 1 show deprecated anchors; 0 don't show
+* `DEPRECATED`: `{0, (1)}` show deprecated anchors
 * `OFFSET`: `{0, 1, (2), ...}` number of spaces to offset docs from anchors
-* `CONNECTED`: `{0, (1)}` 1 ignore docs followed by an empty line; 0 join them
+* `CONNECTED`: `{0, (1)}` ignore docs followed by an empty line
 + Colors:
   + `COLOR_DEFAULT`: (`34`: blue) for anchors whose docs start with `##`
   + `COLOR_ATTENTION`: (`31`: red) for anchors whose docs start with `##!`

--- a/makefile-doc.awk
+++ b/makefile-doc.awk
@@ -9,14 +9,17 @@
 # Usage (see project README.md for more details):
 #   awk [-v option=value] -f makefile-doc.awk [Makefile ...]
 #
-# Options (set using -v option=value, possible values given in {...}, (.) is default):
-#   * VARS: {0, (1)} 1 show documented variables; 0 don't show
+# Options (set using -v option=value, possible values given in {...}, (.) is the default):
+#   + DEBUG: {(0), 1} output debug info (in an org-mode format)
+#   + DEBUG_FILE: debug info file
+#   + EXPANDED_TARGETS: NAME[:LABEL]:[VALUE][;...], see below
+#   + TARGETS_REGEX: regex for matching targets
+#   + VARIABLES_REGEX: regex for matching variables
+#   * VARS: {0, (1)} show documented variables
 #   * PADDING: {(" "), ".", ...} a single padding character between anchors and docs
-#   * DEPRECATED: {0, (1)} 1 show deprecated anchors; 0 don't show
+#   * DEPRECATED: {0, (1)} show deprecated anchors
 #   * OFFSET: {0, 1, (2), ...} number of spaces to offset docs from anchors
-#   * CONNECTED: {0, (1)} 1 ignore docs followed by an empty line; 0 join them
-#   + EXPANDED_TARGETS: NAME[:LABEL]:[VALUE][;...]
-#   + TARGET_REGEX: regex to use for target matching
+#   * CONNECTED: {0, (1)} ignore docs followed by an empty line
 #   * see as well the color codes below
 #
 # Notes:
@@ -39,6 +42,9 @@
 #
 #   Colors are specified using the parameter in ANSI escape codes, e.g., the parameter
 #   for blue is the 34 in `\033[34m`.
+#
+# Expanded_targets:
+#   FIXME: to document
 #
 # Code conventions:
 #   * Variables in a function, to which an assignment is made, should have names ending
@@ -85,19 +91,32 @@ function get_tag_from_description(string) {
 function save_description_data(string) {
   DESCRIPTION_DATA[DESCRIPTION_DATA_INDEX] = string
   DESCRIPTION_DATA_INDEX++
+
+  debug(DEBUG_INDENT_STACK " save_description_data")
+  debug_indent_down()
+  debug_array(DESCRIPTION_DATA, DESCRIPTION_DATA_INDEX, "DESCRIPTION_DATA")
+  debug_indent_up()
 }
 
 function forget_descriptions_data() {
   delete DESCRIPTION_DATA
   DESCRIPTION_DATA_INDEX = 1
+
+  debug(DEBUG_INDENT_STACK " forget_descriptions_data")
+  debug_indent_down()
+  debug_array(DESCRIPTION_DATA, DESCRIPTION_DATA_INDEX, "DESCRIPTION_DATA")
+  debug_indent_up()
 }
 
 function parse_inline_descriptions(whole_line_string) {
+  debug(DEBUG_INDENT_STACK " parse_inline_descriptions")
+  debug_indent_down()
   if (match(whole_line_string, / *(##!|##%|##)/)) {
     inline_string_local = substr(whole_line_string, RSTART)
     sub(/^ */, "", inline_string_local)
     save_description_data(inline_string_local)
   }
+  debug_indent_up()
 }
 
 function parse_variable_name(whole_line_string) {
@@ -121,6 +140,15 @@ function associate_data_with_anchor(anchor_name,
                                     anchors_description_data,
                                     anchors_section_data,
                                     anchor_type) {
+  debug(DEBUG_INDENT_STACK " debug_associate_data_with_" anchor_type " (INITIAL): " anchor_name)
+  debug_indent_down()
+  debug_array(anchors, anchors_index, "anchors", anchor_type)
+  debug_dict(anchors_description_data, "anchors_description_data", anchor_type)
+  debug_dict(anchors_section_data, "anchors_section_data", anchor_type)
+  debug_array(DESCRIPTION_DATA, DESCRIPTION_DATA_INDEX, "DESCRIPTION_DATA")
+  debug_array(SECTION_DATA, SECTION_DATA_INDEX, "SECTION_DATA")
+  debug_indent_up()
+
   if (anchor_name in anchors_description_data) {
     # omit variable related warnings when they are not displayed
     if (anchor_type != "variable" || VARS) {
@@ -153,17 +181,35 @@ function associate_data_with_anchor(anchor_name,
     anchors_section_data[anchor_name] = assemble_section_data()
     forget_section_data()
   }
+
+  debug(DEBUG_INDENT_STACK " debug_associate_data_with_" anchor_type " (FINAL)")
+  debug_indent_down()
+  debug_array(anchors, anchors_index, "anchors", anchor_type)
+  debug_dict(anchors_description_data, "anchors_description_data", anchor_type)
+  debug_dict(anchors_section_data, "anchors_section_data", anchor_type)
+  debug_indent_up()
+
   return anchors_index
 }
 
 function save_section_data(string) {
   SECTION_DATA[SECTION_DATA_INDEX] = string
   SECTION_DATA_INDEX++
+
+  debug(DEBUG_INDENT_STACK " save_section_data")
+  debug_indent_down()
+  debug_array(SECTION_DATA, SECTION_DATA_INDEX, "SECTION_DATA")
+  debug_indent_up()
 }
 
 function forget_section_data() {
   delete SECTION_DATA
   SECTION_DATA_INDEX = 1
+
+  debug(DEBUG_INDENT_STACK " forget_section_data")
+  debug_indent_down()
+  debug_array(SECTION_DATA, SECTION_DATA_INDEX, "SECTION_DATA")
+  debug_indent_up()
 }
 
 function get_associated_section_data(anchor_name,
@@ -420,12 +466,16 @@ function print_help() {
     print "Usage: awk [-v option=value] -f makefile-doc.awk [Makefile ...]"
     print "Description: Generate docs for Makefile variables and targets"
     print "Options:"
-    printf "  EXPANDED_TARGETS: %s\n", EXPANDED_TARGETS
-    printf "  VARS: %s\n", VARS
-    printf "  PADDING: \"%s\"\n", PADDING
-    printf "  DEPRECATED: %s\n", DEPRECATED
-    printf "  OFFSET: %s\n", OFFSET
-    printf "  CONNECTED: %s\n", CONNECTED
+    printf "  DEBUG ([bool] output debug info): %s\n", DEBUG
+    printf "  DEBUG_FILE (debug info file): %s\n", DEBUG_FILE
+    printf "  EXPANDED_TARGETS (NAME[:LABEL]:[VALUE][;...]): %s\n", EXPANDED_TARGETS
+    printf "  TARGETS_REGEX (regex for matching targets): %s\n", TARGETS_REGEX
+    printf "  VARIABLES_REGEX (regex for matching variables): %s\n", VARIABLES_REGEX
+    printf "  VARS ([bool] show documented variables): %s\n", VARS
+    printf "  PADDING (a padding character between anchors and docs): \"%s\"\n", PADDING
+    printf "  DEPRECATED ([bool] show deprecated anchors): %s\n", DEPRECATED
+    printf "  OFFSET (offset of docs from anchors): %s\n", OFFSET
+    printf "  CONNECTED (ignore docs followed by an empty line): %s\n", CONNECTED
     printf "  COLORS: "
     printf "%sDEFAULT%s, ", COLOR_DEFAULT_CODE, COLOR_RESET_CODE
     printf "%sATTENTION%s, ", COLOR_ATTENTION_CODE, COLOR_RESET_CODE
@@ -435,18 +485,158 @@ function print_help() {
     printf "%sBACKTICKS%s\n", COLOR_BACKTICKS_CODE, COLOR_RESET_CODE
 }
 
+# =============================================================================
+# DEBUG STUFF
+# =============================================================================
+function debug(message) {
+  if (DEBUG) {
+    printf "%s\n", message >> DEBUG_FILE
+  }
+}
+
+function debug_indent_up() {
+  DEBUG_INDENT_STACK = substr(DEBUG_INDENT_STACK, 1, length(DEBUG_INDENT_STACK)-1)
+}
+
+function debug_indent_down() {
+  DEBUG_INDENT_STACK = DEBUG_INDENT_STACK "*"
+}
+
+function debug_pattern_rule(title) {
+  debug(DEBUG_INDENT_STACK " line: " FNR " (" title ")")
+  debug_indent_down()
+}
+
+function debug_array(array, array_next_index, array_name, array_note) {
+  if (array_note) {
+    array_note_local = ", note: " array_note
+  } else {
+    array_note_local = ")"
+  }
+  debug(DEBUG_INDENT_STACK " [A] " array_name " (length: " length_array_posix(array) ", next index: " array_next_index array_note_local)
+  for (array_indx_local=1;
+       array_indx_local<=length_array_posix(array);
+       array_indx_local++) {
+    debug("+ " array[array_indx_local])
+  }
+}
+
+function debug_dict(array, array_name, array_note) {
+  if (array_note) {
+    array_note_local = ", note: " array_note
+  } else {
+    array_note_local = ")"
+  }
+
+  debug(DEBUG_INDENT_STACK " [D] " array_name " (length: " length_array_posix(array) array_note_local)
+  for (array_key_local in array) {
+    debug("+ " array_key_local ": " array[array_key_local])
+  }
+}
+
+function debug_init() {
+  debug(DEBUG_INDENT_STACK " debug_init")
+  debug("+ ~FS~: " FS)
+  debug("+ ~DEBUG_FILE~: " DEBUG_FILE)
+  debug("+ ~EXPANDED_TARGETS~: " EXPANDED_TARGETS)
+  debug("+ ~TARGETS_REGEX~: " TARGETS_REGEX)
+  debug("+ ~VARIABLES_REGEX~: " VARIABLES_REGEX)
+  debug("+ ~VARS~: " VARS)
+  debug("+ ~PADDING~: " PADDING)
+  debug("+ ~DEPRECATED~: " DEPRECATED)
+  debug("+ ~OFFSET~: " OFFSET)
+  debug("+ ~CONNECTED~: " CONNECTED)
+  debug("+ ~WIP_TARGET~: " WIP_TARGET)
+}
+
+function debug_FNR1() {
+  debug(DEBUG_INDENT_STACK " debug_FNR1")
+  debug("+ ~number_of_files_processed~: " number_of_files_processed)
+  debug("+ ~files_processed~: " files_processed)
+}
+
+function debug_description_not_section() {
+  debug(DEBUG_INDENT_STACK " debug_description_not_section")
+  debug("+ ~$0~: " $0)
+  debug("+ ~description_string~: " description_string)
+}
+
+function debug_empty_line() {
+  debug(DEBUG_INDENT_STACK " debug_empty_line")
+  debug("+ [before reset] ~WIP_TARGET~:" WIP_TARGET)
+}
+
+function debug_new_section() {
+  debug(DEBUG_INDENT_STACK " debug_new_section")
+  debug("+ ~$0~: " $0)
+  debug("+ ~section_string~: " section_string)
+}
+
+function debug_target_matched() {
+  debug(DEBUG_INDENT_STACK " debug_target_matched")
+  debug("+ ~$0~: " $0)
+  debug("+ ~$1~: " $1)
+  debug("+ ~target_name~: " target_name)
+  debug("+ ~WIP_TARGET~: " WIP_TARGET)
+  debug_indent_down()
+  debug_array(DESCRIPTION_DATA, DESCRIPTION_DATA_INDEX, "DESCRIPTION_DATA")
+  debug_indent_up()
+}
+
+function debug_variable_matched() {
+  debug(DEBUG_INDENT_STACK " debug_variable_matched")
+  debug("+ ~variable_name~: " variable_name)
+  debug_indent_down()
+  debug_array(DESCRIPTION_DATA, DESCRIPTION_DATA_INDEX, "DESCRIPTION_DATA")
+  debug_indent_up()
+}
+
+function debug_END() {
+  debug(DEBUG_INDENT_STACK " debug_END")
+  debug("+ ~max_target_length~: " max_target_length)
+  debug("+ ~max_variable_length~: " max_variable_length)
+  debug("+ ~max_anchor_length~: " max_anchor_length)
+  debug("+ ~separator~: " separator)
+  debug_indent_down()
+  debug_array(DESCRIPTION_DATA, DESCRIPTION_DATA_INDEX, "DESCRIPTION_DATA")
+  debug_array(SECTION_DATA, SECTION_DATA_INDEX, "SECTION_DATA")
+
+  debug_array(TARGETS, TARGETS_INDEX, "TARGETS")
+  debug_dict(TARGETS_DESCRIPTION_DATA, "TARGETS_DESCRIPTION_DATA")
+  debug_dict(TARGETS_SECTION_DATA, "TARGETS_SECTION_DATA")
+
+  debug_array(VARIABLES, VARIABLES_INDEX, "VARIABLES")
+  debug_dict(VARIABLES_DESCRIPTION_DATA, "VARIABLES_DESCRIPTION_DATA")
+  debug_dict(VARIABLES_SECTION_DATA, "VARIABLES_SECTION_DATA")
+
+  debug_dict(EXPANDED_TARGETS_DICT, "EXPANDED_TARGETS_DICT")
+  debug_dict(EXPANDED_TARGETS_DICT_RENAMED, "EXPANDED_TARGETS_DICT_RENAMED")
+  debug_indent_up()
+}
+
+# =============================================================================
+
 # Initialize global variables.
 BEGIN {
+  DEBUG_FILE = DEBUG_FILE == "" ? ".debug-makefile-doc.org" : DEBUG_FILE
+  if (DEBUG) {
+    DEBUG_INDENT_STACK = "*"
+    printf "" > DEBUG_FILE
+  }
+  debug(DEBUG_INDENT_STACK " BEGIN")
+  debug_indent_down()
+
   FS = ":" # set the field separator
 
   ASSIGNMENT_OPERATORS_PATTERN = "(=|:=|::=|:::=|!=|\\?=|\\+=)"
   split("override unexport export private", ARRAY_OF_VARIABLE_QUALIFIERS, " ")
-  VARIABLES_REGEX = sprintf("^ *( *(%s) *)* *[^.#][a-zA-Z0-9_-]* *%s",
-                            join(ARRAY_OF_VARIABLE_QUALIFIERS, "|"),
-                            ASSIGNMENT_OPERATORS_PATTERN)
+  VARIABLES_REGEX_DEFAULT = sprintf("^ *( *(%s) *)* *[^.#][a-zA-Z0-9_-]* *%s",
+                                    join(ARRAY_OF_VARIABLE_QUALIFIERS, "|"),
+                                    ASSIGNMENT_OPERATORS_PATTERN)
   initialize_colors()
 
-  TARGET_REGEX = TARGET_REGEX == "" ? "^ *[^.#][ ,a-zA-Z0-9$_/%.(){}-]* *&?(:|::)( |$)" : TARGET_REGEX
+  VARIABLES_REGEX = VARIABLES_REGEX == "" ? VARIABLES_REGEX_DEFAULT : VARIABLES_REGEX
+  TARGETS_REGEX = TARGETS_REGEX == "" ? "^ *[^.#][ ,a-zA-Z0-9$_/%.(){}-]* *&?(:|::)( |$)" : TARGETS_REGEX
   VARS = VARS == "" ? 1 : VARS
   PADDING = PADDING == "" ? " " : PADDING
   DEPRECATED = DEPRECATED == "" ? 1 : DEPRECATED
@@ -500,40 +690,74 @@ BEGIN {
   VARIABLES_INDEX = 1
 
   split("", DISPLAY_PARAMS)
+
+  debug_init()
+}
+
+{
+  PATTERN_RULE_MATCHED = 0
 }
 
 FNR == 1 {
+  debug_indent_up()
+  debug(DEBUG_INDENT_STACK " FILE: " FILENAME)
+  debug_indent_down()
+  debug_pattern_rule("file counter")
+
   number_of_files_processed++
   if (files_processed) {
     files_processed = files_processed " " FILENAME
   } else {   # I don't want an extra space before or after (affects the diff)
     files_processed = FILENAME
   }
-
+  debug_FNR1()
+  debug_indent_up()
 }
 
 # Capture the line if it is a description (but not a section).
 /^ *##([^@]|$)/ {
+  debug_pattern_rule("description")
+
   description_string = $0
   sub(/^ */, "", description_string)
+
+  debug_description_not_section()
+
   save_description_data(description_string)
+
+  PATTERN_RULE_MATCHED = 1
+  debug_indent_up()
 }
 
 # Flush accumulated descriptions if followed by an empty line.
 /^$/ {
+  debug_pattern_rule("empty line")
+  debug_empty_line()
+
   if (CONNECTED) {
     forget_descriptions_data()
   }
 
   # An empty line ends the definition of a target
   WIP_TARGET = ""
+
+  PATTERN_RULE_MATCHED = 1
+  debug_indent_up()
 }
 
 # New section (all lines in a multi-line sections should start with ##@)
 /^ *##@/ {
+  debug_pattern_rule("new section")
+
   section_string = $0
   sub(/ *##@/, "", section_string) # strip the tags (they are not needed anymore)
+
+  debug_new_section()
+
   save_section_data(section_string)
+
+  PATTERN_RULE_MATCHED = 1
+  debug_indent_up()
 }
 
 # Process target, whose name
@@ -543,13 +767,15 @@ FNR == 1 {
 #  4. There can be multiple space-separated targets on one line (they are captured
 #     together).
 #  5. Targets of the form $(TARGET-NAME) and ${TARGET-NAME} are detected.
-#  6. After the final colon we require either at least one space of end of line -- this
+#  6. After the final colon, we require either at least one space or end of line -- this
 #     is because otherwise we would match VAR := value.
 #  7. FS = ":" is assumed.
 #
 # Note: I have to use *(:|::) instead of *{1,2} because the latter doesn't work in mawk.
 #
-$0 ~ TARGET_REGEX {
+$0 ~ TARGETS_REGEX {
+  debug_pattern_rule("target")
+
   target_name = $1
 
   # remove spaces up to & in grouped targets, e.g., `t1 t2   &` becomes `t1 t2&`
@@ -562,6 +788,8 @@ $0 ~ TARGET_REGEX {
                           count_numb_double_colon(target_name))
   }
 
+  debug_target_matched()
+
   # look for inline descriptions only if there aren't any descriptions above the target
   if (length_array_posix(DESCRIPTION_DATA) == 0 && WIP_TARGET != target_name) {
     parse_inline_descriptions($0) # this might modify DESCRIPTION_DATA
@@ -569,6 +797,7 @@ $0 ~ TARGET_REGEX {
 
   if (length_array_posix(DESCRIPTION_DATA) > 0) {
     WIP_TARGET = target_name
+    debug(DEBUG_INDENT_STACK " [assign] ~WIP_TARGET~: " WIP_TARGET)
     TARGETS_INDEX = associate_data_with_anchor(trim_start_end_spaces(target_name),
                                                TARGETS,
                                                TARGETS_INDEX,
@@ -576,6 +805,9 @@ $0 ~ TARGET_REGEX {
                                                TARGETS_SECTION_DATA,
                                                "target")
   }
+
+  PATTERN_RULE_MATCHED = 1
+  debug_indent_up()
 }
 
 # Process variable, whose name
@@ -585,12 +817,16 @@ $0 ~ TARGET_REGEX {
 #     ASSIGNMENT_OPERATORS_PATTERN
 
 $0 ~ VARIABLES_REGEX {
+  debug_pattern_rule("variable")
+  debug("+ ~$0~: " $0)
+
   if (length_array_posix(DESCRIPTION_DATA) == 0) {
     parse_inline_descriptions($0) # this might modify DESCRIPTION_DATA
   }
 
   if (length_array_posix(DESCRIPTION_DATA) > 0) {
     variable_name = trim_start_end_spaces(parse_variable_name($0))
+    debug_variable_matched()
     VARIABLES_INDEX = associate_data_with_anchor(variable_name,
                                                  VARIABLES,
                                                  VARIABLES_INDEX,
@@ -598,10 +834,23 @@ $0 ~ VARIABLES_REGEX {
                                                  VARIABLES_SECTION_DATA,
                                                  "variable")
   }
+
+  PATTERN_RULE_MATCHED = 1
+  debug_indent_up()
+}
+
+PATTERN_RULE_MATCHED == 0 {
+  debug_pattern_rule("bucket")
+  debug("+ ~$0~: " $0)
+  debug_indent_up()
 }
 
 # Display results (except for warnings all stdout is here).
 END {
+  debug_indent_up()
+  debug(DEBUG_INDENT_STACK " END")
+  debug_indent_down()
+
   # EXPANDED_TARGETS_DICT_RENAMED should be formed before get_max_anchor_length
   # in order to account for renamed targets
   form_expanded_targets()
@@ -610,6 +859,8 @@ END {
   max_variable_length = get_max_anchor_length(VARIABLES)
   max_anchor_length = max(max_target_length, max_variable_length)
   separator = get_separator(max_anchor_length)
+
+  debug_END()
 
   # process targets
   if (max_target_length > 0) {
@@ -646,5 +897,10 @@ END {
     if (number_of_files_processed > 0) {
       printf("There are no documented targets/variables in %s\n", files_processed)
     }
+  }
+
+  if (DEBUG) {
+    close(DEBUG_FILE)
+    print "Debug info written in " DEBUG_FILE
   }
 }

--- a/test/Makefile.inc
+++ b/test/Makefile.inc
@@ -1,3 +1,4 @@
+DEBUG =
 CONNECTED =
 PADDING =
 HEADER =
@@ -14,6 +15,7 @@ AWK_FLAGS :=
 ## second line in the description of the target help
 help:
 	@bin/$(AWK) $(AWK_FLAGS) -v PADDING=$(PADDING) \
+		-v DEBUG=$(DEBUG) \
 		-v CONNECTED=$(CONNECTED) \
 		-v DEPRECATED=$(DEPRECATED) \
 		-v COLOR_BACKTICKS=$(COLOR_BACKTICKS) \


### PR DESCRIPTION
Resolves #26 and partially addresses #28.

Now we can define 

```Makefile
help: SCR := /path/to/makefile-doc.awk
help: ## Show this help
	@awk -v $(DEBUG) -f $(SCR) $(MAKEFILE_LIST)
```
and use `make DEBUG=1` whenever debug info is needed. The debug info is in org-mode format. 

Unit tests will be added in a separate PR.