### PR TITLE
Bugfix: multiline backslash comments/commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ $(INTEGRATION_TESTS): FILE_EXPECTED = /tmp/.makefile-doc_$@_expected
 $(INTEGRATION_TESTS): FILE_ACTUAL = /tmp/.makefile-doc_$@_actual
 $(INTEGRATION_TESTS): RECIPE_CMD = $(shell head -n 1 $(INTEGRATION_TEST_DIR)/$@)
 $(INTEGRATION_TESTS): $(AWK_BIN)/$(AWK)
-	@echo "$(subst $,\$,$(RECIPE_CMD))" > $(FILE_CMD);
+	@echo "$(subst $,\$,$(RECIPE_CMD))" > $(FILE_CMD)
 	@tail -n +2 $(INTEGRATION_TEST_DIR)/$@ > $(FILE_EXPECTED)
 	@$< -f $(MAKEFILE_DOC) $(AWK_FLAGS) $(RECIPE_CMD) \
 		> $(FILE_ACTUAL).stdout 2> $(FILE_ACTUAL).stderr || exit 0

--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ without `#`). Foreground/background can be set using the tokens `FG/BG`. Unspeci
   + [wak](https://github.com/raygard/wak) `v24.10`
   + [goawk](https://github.com/benhoyt/goawk) `v1.29.1`
 + `GNU Make`
+  + version 3.81 works fine for documentation generation
+  + I run the tests with version 4.3
 
 ## Running the tests
 

--- a/test/Makefile.backslash-comments
+++ b/test/Makefile.backslash-comments
@@ -40,6 +40,16 @@ vvv5 := 1 ## 5
 z5:
 	@echo $(vvv5)
 
+## Spaces\ \
+sss2 := 1 ## 2
+s2:
+	@echo $(sss2)
+
+## Spaces\ \   \ \
+sss3 := 1 ## 3
+s3:
+	@echo $(sss3)
+
 ## should ignore this comment and the variable
 ## which is a part of the above recipe
 	BAD := 1

--- a/test/Makefile.backslash-recipe
+++ b/test/Makefile.backslash-recipe
@@ -28,6 +28,16 @@ t5: ## i-t5
 	@echo maybe\\\\\
 T5 := 1 ## v-t5 (this is not a variable)
 
+## spaces between backslashes
+s2:
+	@echo maybe\ \
+S2 := 1 ## v-s2 (this is not a variable)
+
+## spaces between backslashes
+s3:
+	@echo maybe\ \   \ \
+S3 := 1 ## v-s3 (this is not a variable)
+
 t6: ## i-t6
 	@echo maybe\
 T6_1 := 1 \

--- a/test/integration/test-backslash-recipe
+++ b/test/integration/test-backslash-recipe
@@ -8,6 +8,8 @@ Available targets:
 [34mt3[0m   t-t3
 [34mt4[0m   t-t4
 [34mt5[0m   t-t5
+[34ms2[0m   spaces between backslashes
+[34ms3[0m   spaces between backslashes
 [34mt6[0m   i-t6
 [34mt7[0m   i-t7
 [34mt8[0m   i-t7


### PR DESCRIPTION
The regex for multiline backslash in comments and commands didn't handle correctly spaces between backslashes. 